### PR TITLE
Input chunks should be joined without any characters in between them

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ stdin.on('data', (chunk) => {
 });
 
 stdin.on('end', () => {
-  const jestJsonOutput = inputChunks.join();
+  const jestJsonOutput = inputChunks.join('');
   const jestOutput = parseJestJsonOutput(jestJsonOutput);
 
   stdout.write(jestOutputToTab(jestOutput));


### PR DESCRIPTION
When stdin is split into multiple chunks, an extra `,` is inserted in between, causing the concatenated string to be invalid json.

From `Array.prototype.join()` documentation:
> The separator is converted to a string if necessary. If omitted, the array elements are separated with a comma (",").
> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join#Parameters

This PR fixes this