### PR TITLE
fix: check for failed test suites

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ stdin.on('end', () => {
   stdout.write(jestOutputToTab(jestOutput));
   stdout.write('\n');
 
-  if (jestOutput.numFailedTests > 0) {
+  if (jestOutput.numFailedTests > 0 || jestOutput.numFailedTestSuites > 0) {
     // eslint-disable-next-line no-process-exit
     process.exit(1);
   }


### PR DESCRIPTION
We need to also check if any suites failed. In the event they did (for example, `ts-jest` build failures), then `numFailedTests === 0`  but suite failures would exist.